### PR TITLE
Fix kwargs bug

### DIFF
--- a/src/torchliter/engine/base.py
+++ b/src/torchliter/engine/base.py
@@ -253,7 +253,7 @@ class EngineBase:
             )
 
         self.epoch_length = len(dataloader)
-        self.when_epoch_starts(**kwargs)
+        self.when_epoch_starts()
         try:
             # if current stub was paused, then pick up from there
             stub_iteration = max(0, int(self.current_stub.iteration))
@@ -264,12 +264,12 @@ class EngineBase:
 
         for batch in dataloader:
             try:
-                self.before_iteration(**kwargs)
+                self.before_iteration()
                 self.per_batch(batch, **kwargs)  # the iteration
                 self.current_stub.iteration += 1
                 if self.is_train_stub:
                     self.iteration += 1
-                self.after_iteration(**kwargs)
+                self.after_iteration()
                 if self.iteration == self.epoch_length:
                     # terminate such that total iterations equal epoch length
                     # NOTE: so far assume sampling with replacement
@@ -288,7 +288,7 @@ class EngineBase:
         # update engine epoch only when stub is Train
         if self.is_train_stub:
             self.epoch += 1
-        self.when_epoch_finishes(**kwargs)
+        self.when_epoch_finishes()
 
     def queue(self, stubs: List[StubBase]) -> None:
         """

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -1,13 +1,10 @@
 import inspect
 import pickle
 
-import torch
-
 import torchliter
 
 
 def test_sequence_container():
-
     container = torchliter.engine.buffers.SequenceContainer()
     assert container.values == []
     for i in range(5):
@@ -18,7 +15,6 @@ def test_sequence_container():
 
 
 def test_scaler_buffer():
-
     scaler = torchliter.engine.buffers.ScalarSmoother(3)
     print(scaler)
 
@@ -49,7 +45,6 @@ def test_scaler_buffer():
 
 
 def test_scalar_summary_statistics():
-
     b = torchliter.engine.buffers.ScalarSummaryStatistics()
     b(1.0)
     b(2.0)
@@ -64,10 +59,9 @@ def test_scalar_summary_statistics():
 
 
 def test_exponential_moving_average_buffer():
-
     scaler = torchliter.engine.buffers.ExponentialMovingAverage(1 / 3)
 
-    assert scaler.mean == 0.0
+    assert scaler.mean is None
     assert scaler.variance == 0.0
 
     scaler(0)
@@ -87,121 +81,6 @@ def test_exponential_moving_average_buffer():
 
     assert new_scaler._count == scaler._count
     assert new_scaler.mean == scaler.mean
-
-
-def test_vector_buffer():
-
-    float_vector = torchliter.engine.buffers.VectorSmoother(
-        0.5, 8, 2.0, normalize=True, device="cpu", dtype=torch.float
-    )
-    assert float_vector.mean.dtype == torch.float
-
-    long_vector = torchliter.engine.buffers.VectorSmoother(
-        0.5, 8, 2.0, normalize=False, device="cpu", dtype=torch.long
-    )
-    assert long_vector.mean.dtype == torch.long
-
-    if torch.cuda.is_available():
-        float_vector = torchliter.engine.buffers.VectorSmoother(
-            0.5, 8, 2.0, normalize=True, device="cuda:0", dtype=torch.float
-        )
-        assert float_vector.mean.dtype == torch.float
-        assert float_vector.mean.device == torch.device("cuda:0")
-
-    vector = torchliter.engine.buffers.VectorSmoother(0.5, 8, 2.0, normalize=False)
-    print(vector)
-
-    torch.tensor([2.0] * 8).float()
-
-    assert vector.l1_norm == 2.0 * 8
-    assert vector.l2_norm == (2.0**2 * 8) ** 0.5
-    assert (vector.l1_normalized == 1 / 8 * torch.ones(8).float()).all()
-    assert (vector.l2_normalized == (1 / 8**0.5) * torch.ones(8).float()).all()
-
-    vector(torch.zeros(8))
-    assert (vector.vector == 2 * torch.ones(8) * 0.5).all()
-    vector(torch.zeros(8))
-    assert (vector.vector == 2 * torch.ones(8) * 0.5**2).all()
-    vector(torch.zeros(8))
-    assert (vector.vector == 2 * torch.ones(8) * 0.5**3).all()
-
-    assert vector._count == 3
-
-    state = vector.state_dict()
-    assert state["count"] == 3
-
-    state = pickle.dumps(state)
-
-    new_vector = torchliter.engine.buffers.VectorSmoother(0.5, 8, 2.0)
-    new_vector.load_state_dict(pickle.loads(state))
-    assert new_vector._count == 3
-    assert (new_vector.mean == 2 * torch.ones(8).float() * 0.5**3).all()
-
-    # l1-normalized
-    vector = torchliter.engine.buffers.VectorSmoother(
-        0.5, 8, 2.0, normalize=True, p=1.0
-    )
-    print(vector)
-
-    assert vector.l1_norm == 1.0
-    assert vector.l2_norm == ((1 / 8) ** 2 * 8) ** 0.5
-    assert (vector.l1_normalized == 1 / 8 * torch.ones(8).float()).all()
-    assert (vector.l2_normalized == (1 / 8**0.5) * torch.ones(8).float()).all()
-
-    vector(torch.zeros(8).float())
-    assert (vector.vector == torch.ones(8).float() / 8).all()
-    vector(torch.zeros(8).float())
-    assert (vector.vector == torch.ones(8).float() / 8).all()
-    vector(torch.zeros(8).float())
-    assert (vector.vector == torch.ones(8).float() / 8).all()
-
-    assert vector._count == 3
-
-    state = vector.state_dict()
-    assert state["count"] == 3
-
-    state = pickle.dumps(state)
-
-    new_vector = torchliter.engine.buffers.VectorSmoother(
-        0.5, 8, 2.0, normalize=True, p=1.0
-    )
-    new_vector.load_state_dict(pickle.loads(state))
-    assert new_vector._count == 3
-    assert (new_vector.mean == torch.ones(8).float() / 8).all()
-
-    # l2-normalized
-    vector = torchliter.engine.buffers.VectorSmoother(
-        0.5, 8, 2.0, normalize=True, p=2.0
-    )
-    print(vector)
-
-    assert (vector.l1_norm - 8**0.5).abs() < 1e-6  # (1/8)**0.5 * 8
-    assert (vector.l2_norm - 1.0).abs() < 1e-6
-    assert ((vector.l1_normalized - 1 / 8 * torch.ones(8).float()).abs() < 1e-6).all()
-    assert (
-        (vector.l2_normalized - (1 / 8**0.5) * torch.ones(8).float()).abs() < 1e-6
-    ).all()
-
-    vector(torch.zeros(8).float())
-    assert ((vector.vector - torch.ones(8).float() / 8**0.5).abs() < 1e-6).all()
-    vector(torch.zeros(8).float())
-    assert ((vector.vector - torch.ones(8).float() / 8**0.5).abs() < 1e-6).all()
-    vector(torch.zeros(8).float())
-    assert ((vector.vector - torch.ones(8).float() / 8**0.5).abs() < 1e-6).all()
-
-    assert vector._count == 3
-
-    state = vector.state_dict()
-    assert state["count"] == 3
-
-    state = pickle.dumps(state)
-
-    new_vector = torchliter.engine.buffers.VectorSmoother(
-        0.5, 8, 2.0, normalize=True, p=2.0
-    )
-    new_vector.load_state_dict(pickle.loads(state))
-    assert new_vector._count == 3
-    assert ((new_vector.mean - torch.ones(8).float() / 8**0.5).abs() < 1e-6).all()
 
 
 class SimpleClass:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -211,5 +211,5 @@ def test_auto_engine():
         example=0.618,
     )
 
-    assert test_engine.train_kwarg.mean == 0.0122982
+    assert test_engine.train_kwarg.mean == 0.618
     assert test_engine.eval_kwarg.mean == 0.618


### PR DESCRIPTION
Now user can pass kwargs in `engine(stubs, kwarg_1=1.0, kwarg_2=2)` and the kwargs can be picked up by `train_step`, `eval_step`, and `lambda_step` functions.